### PR TITLE
fix(catch-net): stop the intent-site detector flagging the journals that report on it

### DIFF
--- a/scripts/check-evolves-not-deprecates.sh
+++ b/scripts/check-evolves-not-deprecates.sh
@@ -40,13 +40,22 @@ if [ "${broad:-0}" -lt 5 ]; then
   exit 2
 fi
 
+# The 'deprecat' test runs against a SCRUBBED copy of each line with SIG-*/JRN-*
+# filename tokens removed, while the ORIGINAL line is what gets reported. A line
+# that merely CITES a signal or journal whose filename contains "deprecation" is a
+# citation, not an assertion about intent-site's status. Reporting those was a
+# false positive that GREW every week, because each sweep's journal recorded the
+# previous sweep's triage and became next week's match.
+# See SIG-2026-08-31-s12-detector-flags-its-own-journals.
 matches="$(grep -rniE 'intent-site' "$ROOT" \
   --include='*.md' \
   --exclude-dir='.git' \
   --exclude-dir='.intent' \
   --exclude-dir='archive' \
+  --exclude-dir='journal' \
   2>/dev/null \
-  | grep -iE 'deprecat' \
+  | awk '{ scrub=$0; gsub(/(SIG|JRN)-[A-Za-z0-9._-]*/, "", scrub);
+           if (tolower(scrub) ~ /deprecat/) print $0 }' \
   | grep -ivE 'evolv|not[ -]deprecat|gates? on phase|deprecation gate|eventual|stage 4')"
 
 if [ -n "$matches" ]; then

--- a/scripts/test-evolves-not-deprecates.sh
+++ b/scripts/test-evolves-not-deprecates.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Falsification harness for check-evolves-not-deprecates.sh.
+#
+# Exists because 2026-08-31 narrowed that detector's scope (journal/ excluded,
+# SIG-/JRN- filename tokens scrubbed before the 'deprecat' test). Narrowing a
+# guard without a test that proves it still fires is how a guard goes quietly
+# blind. This asserts BOTH directions on every run:
+#   - a bald unqualified claim STILL trips it (exit 1)
+#   - citations, journals and canon-qualified lines DO NOT (exit 0)
+#
+# Exit 0 = detector behaves correctly. Exit 1 = detector regressed.
+set -u
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/check-evolves-not-deprecates.sh"
+[ -x "$SCRIPT" ] || { echo "ERROR: detector not executable: $SCRIPT" >&2; exit 1; }
+FIX="$(mktemp -d)"; trap 'rm -rf "$FIX"' EXIT
+mkdir -p "$FIX/docs" "$FIX/journal"
+# The sanity gate needs >=5 'intent-site' refs before it will scan at all.
+i=1; while [ $i -le 6 ]; do echo "intent-site reference line $i" > "$FIX/docs/pad$i.md"; i=$((i+1)); done
+echo 'See SIG-EXEC-2026-06-05-ecosystem-deprecation-correction.md. intent-site context.' > "$FIX/docs/citation.md"
+echo 'intent-site is deprecating, said the old sweep.' > "$FIX/journal/JRN-x.md"
+echo 'intent-site evolves in place; deprecation gates on Phase 3.' > "$FIX/docs/qualified.md"
+
+fail=0
+# Direction 1: clean corpus (citation + journal + qualified only) must pass.
+"$SCRIPT" "$FIX" >/dev/null 2>&1
+[ $? -eq 0 ] || { echo "FAIL: detector flagged a citation/journal/qualified-only corpus (false positive regression)"; fail=1; }
+# Direction 2: add a bald claim; it MUST trip.
+echo 'The intent-site product is being deprecated this quarter.' > "$FIX/docs/real-drift.md"
+"$SCRIPT" "$FIX" >/dev/null 2>&1
+[ $? -eq 1 ] || { echo "FAIL: detector did NOT flag a bald unqualified deprecation claim (guard has gone blind)"; fail=1; }
+
+[ $fail -eq 0 ] && echo "OK: check-evolves-not-deprecates.sh fires on real drift and ignores citations/journals."
+exit $fail


### PR DESCRIPTION
Found by the weekly overwatch sweep, 2026-08-31.

Section 12 has exited 1 for three consecutive weeks. None of the flagged lines was a real drift. Three of four were **previous overwatch journals recording that this check produced a false positive** - writing that record created a new descriptive doc coupling `intent-site` with `deprecating`, which the next sweep then flagged.

The false-positive set was growing by one per week, and the sweep was the thing growing it. That is Section 11's own subject matter (incestuous amplification) expressed in an instrument rather than a conclusion: the detector was reading its own reporting as evidence about the world.

## Change

Extends the exclusion rationale the script already documents in its own header:

- `journal/` joins `.intent/` and `archive/` as an excluded point-in-time-record surface.
- The `deprecat` test runs against a **scrubbed** copy of each line with `SIG-*`/`JRN-*` filename tokens removed, while the **original** line is what gets reported. Only the filename is neutralized; the rest of the line stays under full scrutiny.

## Verification

Narrowing a guard without proving it still fires is how a guard goes blind, so this adds `scripts/test-evolves-not-deprecates.sh`, which asserts **both** directions on every run:

- a bald unqualified claim still trips the detector (exit 1)
- citations, journals and canon-qualified lines do not (exit 0)

It passes. Live run post-fix: exit 0 across 1172 `intent-site` refs.

## Accepted trade

A genuine drift claim written *inside a journal directory* is no longer caught. Journals are records of past observation, not statements of current canon, and treating them as canon is what produced this defect.